### PR TITLE
feat(core): reject issue status update if report has next step

### DIFF
--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
@@ -1623,6 +1623,7 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
     });
 
     it('should not reject when last comment has JSON block with invalid JSON', async () => {
+      const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation();
       const issue = createMockIssue({
         url: 'https://github.com/user/repo/issues/1',
         status: 'Preparation',
@@ -1663,6 +1664,11 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
         }),
         mockProject,
       );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        'Invalid JSON in report body while checking nextStep:',
+        expect.any(Error),
+      );
+      consoleWarnSpy.mockRestore();
     });
 
     it('should not reject when last comment has JSON block with non-object value', async () => {

--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
@@ -223,7 +223,11 @@ export class NotifyFinishedIssuePreparationUseCase {
     let reportJson: unknown;
     try {
       reportJson = JSON.parse(reportMatch[1]);
-    } catch {
+    } catch (error) {
+      console.warn(
+        'Invalid JSON in report body while checking nextStep:',
+        error,
+      );
       return false;
     }
     if (typeof reportJson !== 'object' || reportJson === null) {


### PR DESCRIPTION
## Summary
- Add `REPORT_HAS_NEXT_STEP` rejection reason to `NotifyFinishedIssuePreparationUseCase`
- When the last agent bot comment contains a JSON block with a non-null `nextStep` field, the issue is rejected back to awaiting workspace status
- Implementation uses `reportBodyHasNextStep` private method that parses the JSON code block from the comment body

## Test plan
- [x] Rejects with `REPORT_HAS_NEXT_STEP` when last comment has `nextStep` with non-null value
- [x] Does NOT reject when `nextStep` is `null`
- [x] Does NOT reject when JSON report has no `nextStep` field
- [x] Does NOT reject when last comment has no JSON block
- [x] Does NOT reject when JSON block contains invalid JSON
- [x] Does NOT reject when JSON block parses to a non-object value
- [x] 100% code coverage maintained

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)