### PR TITLE
fix(core): correct typo in auto-rejection message and document thresholdForAutoReject

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,15 @@ The GitHub Project README can contain a collapsible `<details>` section with YAM
 maximumPreparingIssuesCount: 2
 utilizationPercentageThreshold: 99
 defaultAgentName: 'custom-agent'
+thresholdForAutoReject: 3
 </details>
 ```
 
 Only the content inside the `<details><summary>config</summary>` section is parsed as YAML. Other content in the README is ignored. `projectUrl` and `configFilePath` cannot be set via Project README since the README is fetched using these values.
+
+### Parameters
+
+- `thresholdForAutoReject` (default: `3`) - Number of consecutive auto-rejection comments before automatically escalating the issue to the awaiting quality check status. Can be set via CLI argument `--thresholdForAutoReject`, config file, or GitHub Project README config.
 
 ### Issue Labels
 

--- a/bin/domain/usecases/NotifyFinishedIssuePreparationUseCase.js
+++ b/bin/domain/usecases/NotifyFinishedIssuePreparationUseCase.js
@@ -42,10 +42,10 @@ class NotifyFinishedIssuePreparationUseCase {
             if (lastTargetComments.filter((comment) => comment.content.startsWith('Auto Status Check: REJECTED')).length >= params.thresholdForAutoReject &&
                 !lastTargetComments.some((comment) => comment.content
                     .toLowerCase()
-                    .includes('failed to pass the check autimatically'))) {
+                    .includes('failed to pass the check automatically'))) {
                 issue.status = params.awaitingQualityCheckStatus;
                 await this.issueRepository.update(issue, project);
-                await this.issueCommentRepository.createComment(issue, `${rejectionStatusMessage}\n\nFailed to pass the check autimatically for ${params.thresholdForAutoReject} times`);
+                await this.issueCommentRepository.createComment(issue, `${rejectionStatusMessage}\n\nFailed to pass the check automatically for ${params.thresholdForAutoReject} times`);
                 await this.sendWorkflowBlockerNotification(params.issueUrl, params.workflowBlockerResolvedWebhookUrl, project);
                 return;
             }

--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
@@ -442,7 +442,7 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
     );
     expect(createCommentCall[1]).toContain('Auto Status Check:');
     expect(createCommentCall[1]).toContain(
-      'Failed to pass the check autimatically for 3 times',
+      'Failed to pass the check automatically for 3 times',
     );
   });
 
@@ -501,7 +501,7 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
       createMockComment({ content: 'Auto Status Check: REJECTED - second' }),
       createMockComment({ content: 'Auto Status Check: REJECTED - third' }),
       createMockComment({
-        content: 'Failed to pass the check autimatically for 3 times',
+        content: 'Failed to pass the check automatically for 3 times',
       }),
     ]);
     mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
@@ -547,7 +547,7 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
       createMockComment({ content: 'Auto Status Check: REJECTED - second' }),
       createMockComment({ content: 'Auto Status Check: REJECTED - third' }),
       createMockComment({
-        content: 'Failed to pass the check autimatically for 5 times',
+        content: 'Failed to pass the check automatically for 5 times',
       }),
     ]);
     mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([
@@ -594,7 +594,7 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
       createMockComment({ content: 'Auto Status Check: REJECTED - third' }),
       createMockComment({
         content:
-          'Auto Status Check: REJECTED\n- NO_REPORT_FROM_AGENT_BOT\n\nFailed to pass the check autimatically for 3 times',
+          'Auto Status Check: REJECTED\n- NO_REPORT_FROM_AGENT_BOT\n\nFailed to pass the check automatically for 3 times',
       }),
     ]);
     mockIssueRepository.findRelatedOpenPRs.mockResolvedValue([

--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
@@ -104,14 +104,14 @@ export class NotifyFinishedIssuePreparationUseCase {
       !lastTargetComments.some((comment) =>
         comment.content
           .toLowerCase()
-          .includes('failed to pass the check autimatically'),
+          .includes('failed to pass the check automatically'),
       )
     ) {
       issue.status = params.awaitingQualityCheckStatus;
       await this.issueRepository.update(issue, project);
       await this.issueCommentRepository.createComment(
         issue,
-        `${rejectionStatusMessage}\n\nFailed to pass the check autimatically for ${params.thresholdForAutoReject} times`,
+        `${rejectionStatusMessage}\n\nFailed to pass the check automatically for ${params.thresholdForAutoReject} times`,
       );
       await this.sendWorkflowBlockerNotification(
         params.issueUrl,


### PR DESCRIPTION
## Summary

- Fix typo 'autimatically' → 'automatically' in user-facing escalation message and guard check
- Update test assertions to match corrected message
- Update bin/ build artifact with corrected message
- Add `thresholdForAutoReject` parameter documentation to README

## Background

Issue #174 requested that the retry count for auto-rejection be parametrized. This was already implemented via `--thresholdForAutoReject` CLI option. This PR fixes the typo in the message and documents the parameter in README.

## Test plan

- All 302 unit tests pass locally
- Format check passes
- TypeScript builds successfully

Closes #174