### PR TITLE
fix(core): exclude cross-referenced PRs that do not close the issue from findRelatedOpenPRs

### DIFF
--- a/src/adapter/repositories/GraphqlIssueRepository.test.ts
+++ b/src/adapter/repositories/GraphqlIssueRepository.test.ts
@@ -559,6 +559,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -599,6 +600,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -637,6 +639,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -665,6 +668,58 @@ describe('GraphqlIssueRepository', () => {
       expect(result[0].isResolvedAllReviewComments).toBe(false);
     });
 
+    it('should filter out PRs that do not close the issue (willCloseTarget: false)', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            repository: {
+              issue: {
+                timelineItems: {
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                  nodes: [
+                    {
+                      __typename: 'CrossReferencedEvent',
+                      willCloseTarget: false,
+                      source: {
+                        __typename: 'PullRequest',
+                        url: 'https://github.com/user/repo/pull/1',
+                        state: 'OPEN',
+                        mergeable: 'MERGEABLE',
+                        commits: { nodes: [] },
+                        reviewThreads: { nodes: [] },
+                        baseRef: { name: 'main' },
+                      },
+                    },
+                    {
+                      __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
+                      source: {
+                        __typename: 'PullRequest',
+                        url: 'https://github.com/user/repo/pull/2',
+                        state: 'OPEN',
+                        mergeable: 'MERGEABLE',
+                        commits: { nodes: [] },
+                        reviewThreads: { nodes: [] },
+                        baseRef: { name: 'main' },
+                      },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        }),
+      });
+
+      const result = await repository.findRelatedOpenPRs(
+        'https://github.com/user/repo/issues/1',
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].url).toBe('https://github.com/user/repo/pull/2');
+    });
+
     it('should filter out closed PRs', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -677,6 +732,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -685,6 +741,7 @@ describe('GraphqlIssueRepository', () => {
                     },
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/2',
@@ -724,6 +781,7 @@ describe('GraphqlIssueRepository', () => {
                     nodes: [
                       {
                         __typename: 'CrossReferencedEvent',
+                        willCloseTarget: true,
                         source: {
                           __typename: 'PullRequest',
                           url: 'https://github.com/user/repo/pull/1',
@@ -752,6 +810,7 @@ describe('GraphqlIssueRepository', () => {
                     nodes: [
                       {
                         __typename: 'CrossReferencedEvent',
+                        willCloseTarget: true,
                         source: {
                           __typename: 'PullRequest',
                           url: 'https://github.com/user/repo/pull/2',
@@ -838,6 +897,7 @@ describe('GraphqlIssueRepository', () => {
                     { __typename: 'IssueComment' },
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -875,10 +935,12 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: { __typename: 'Issue' },
                     },
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -916,6 +978,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: null,
                     },
                   ],
@@ -958,6 +1021,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: undefined,
@@ -1000,6 +1064,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1039,6 +1104,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1086,6 +1152,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1134,6 +1201,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1213,6 +1281,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1293,6 +1362,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1368,6 +1438,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1430,6 +1501,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1504,6 +1576,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1573,6 +1646,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1647,6 +1721,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1716,6 +1791,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1785,6 +1861,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1854,6 +1931,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1923,6 +2001,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -1992,6 +2071,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2061,6 +2141,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2134,6 +2215,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2202,6 +2284,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2275,6 +2358,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2344,6 +2428,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2417,6 +2502,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2518,6 +2604,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2608,6 +2695,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2689,6 +2777,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2770,6 +2859,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2859,6 +2949,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -2940,6 +3031,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -3036,6 +3128,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -3125,6 +3218,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -3206,6 +3300,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -3287,6 +3382,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -3376,6 +3472,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -3457,6 +3554,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',
@@ -3534,6 +3632,7 @@ describe('GraphqlIssueRepository', () => {
                   nodes: [
                     {
                       __typename: 'CrossReferencedEvent',
+                      willCloseTarget: true,
                       source: {
                         __typename: 'PullRequest',
                         url: 'https://github.com/user/repo/pull/1',

--- a/src/adapter/repositories/GraphqlIssueRepository.ts
+++ b/src/adapter/repositories/GraphqlIssueRepository.ts
@@ -757,6 +757,7 @@ export class GraphqlIssueRepository implements Pick<
         if (item.__typename !== 'CrossReferencedEvent') continue;
         if (!item.source || item.source.__typename !== 'PullRequest') continue;
         if (item.source.state !== 'OPEN') continue;
+        if (!item.willCloseTarget) continue;
 
         const pr = item.source;
         const prUrl = pr.url || '';


### PR DESCRIPTION
## Summary
- Add `if (!item.willCloseTarget) continue;` filter in `findRelatedOpenPRs` in `GraphqlIssueRepository.ts`
- PRs that mention an issue without a closing keyword (e.g. "fixes", "closes") have `willCloseTarget=false` in GitHub's GraphQL API
- Without this filter, such PRs were incorrectly included in `findRelatedOpenPRs`, causing false `MULTIPLE_PULL_REQUESTS_FOUND` rejections when multiple PRs referenced the same issue but only one was intended to close it

## Test plan
- [ ] New test: `should filter out PRs that do not close the issue (willCloseTarget: false)` — verifies that a PR with `willCloseTarget: false` is excluded while one with `willCloseTarget: true` is included
- [ ] All 48 existing `CrossReferencedEvent` mock objects updated with `willCloseTarget: true` to maintain existing behavior
- [ ] 79 tests pass (up from 78) in `GraphqlIssueRepository.test.ts`

Closes #189

🤖 Generated with [Claude Code](https://claude.com/claude-code)