### PR TITLE
fix(core): NotifyFinish has wrong auto check when it has llm-agent label

### DIFF
--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.test.ts
@@ -1145,11 +1145,11 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
     );
   });
 
-  it('should skip PR checks and update to Awaiting Quality Check when issue has llm-agent label', async () => {
+  it('should skip PR checks and update to Awaiting Quality Check when issue has llm-agent:research label', async () => {
     const issue = createMockIssue({
       url: 'https://github.com/user/repo/issues/1',
       status: 'Preparation',
-      labels: ['llm-agent'],
+      labels: ['llm-agent:research'],
     });
 
     mockProjectRepository.getByUrl.mockResolvedValue(mockProject);
@@ -1177,11 +1177,11 @@ describe('NotifyFinishedIssuePreparationUseCase', () => {
     );
   });
 
-  it('should still check for report comment even when issue has llm-agent label', async () => {
+  it('should still check for report comment even when issue has llm-agent:research label', async () => {
     const issue = createMockIssue({
       url: 'https://github.com/user/repo/issues/1',
       status: 'Preparation',
-      labels: ['llm-agent'],
+      labels: ['llm-agent:research'],
     });
 
     mockProjectRepository.getByUrl.mockResolvedValue(mockProject);

--- a/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
+++ b/src/domain/usecases/NotifyFinishedIssuePreparationUseCase.ts
@@ -212,7 +212,9 @@ export class NotifyFinishedIssuePreparationUseCase {
     const categoryLabels = issue.labels.filter((label) =>
       label.startsWith('category:'),
     );
-    const hasLlmAgentLabel = issue.labels.includes('llm-agent');
+    const hasLlmAgentLabel = issue.labels.some(
+      (l) => l === 'llm-agent' || l.startsWith('llm-agent:'),
+    );
     if (
       !hasLlmAgentLabel &&
       (categoryLabels.length <= 0 || categoryLabels.includes('category:e2e'))


### PR DESCRIPTION
## Summary

Skip PR check when issue has llm-agent label, consistent with behavior for category-labeled issues. Pull request is required only when the issue has no category label and no llm-agent label.

- close #218