### PR TITLE
chore(deps): bump undici security vulnerabilities (CVE-2026-1525, CVE-2026-1526, CVE-2026-1527, CVE-2026-1528, CVE-2026-2229)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4358,9 +4358,9 @@
       }
     },
     "node_modules/cheerio/node_modules/undici": {
-      "version": "7.21.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-      "integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+      "version": "7.24.7",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+      "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"
@@ -15061,9 +15061,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.17"


### PR DESCRIPTION
Update undici transitive dependencies to address critical and high security vulnerabilities:\n\n- CVE-2026-1525 (Medium): Inconsistent interpretation of HTTP requests\n- CVE-2026-1526 (High): Unbounded memory consumption in WebSocket permessage-deflate decompression\n- CVE-2026-1527 (Medium): CRLF injection via the upgrade option\n- CVE-2026-1528 (High): Malicious WebSocket 64-bit frame length handling could crash the client\n- CVE-2026-2229 (High): Unhandled exception from invalid server_max_window_bits in WebSocket permessage-deflate negotiation\n\nChanges:\n- node_modules/undici: 6.23.0 → 6.24.1\n- node_modules/cheerio/node_modules/undici: 7.21.0 → 7.24.7\n\n- close #227