### PR TITLE
fix(publish): pass NPM_TOKEN to semantic-release step

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,6 +38,7 @@ jobs:
       - run: npx semantic-release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - run: |
           git status
           git add -A


### PR DESCRIPTION
## Summary

The publish workflow was missing NPM_TOKEN in the env section of the semantic-release step, causing ENONPMTOKEN failures on every push to main since 2026-04-04. The secret exists in repository settings but was not being passed through to the semantic-release process.

## Root Cause

`@semantic-release/npm` first attempts OIDC token exchange (fails with 404), then falls back to NPM_TOKEN env var. Since NPM_TOKEN was not in the step's env, it defaulted to nothing.

- close #229